### PR TITLE
Replace globe icon with minimal calculator in header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Git
 
-Never include a Claude session URL in commit messages.
+Never include a Claude session URL in commit messages or pull request descriptions.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git
+
+Never include a Claude session URL in commit messages.
+
 ## Commands
 
 ```bash

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="#FFE01B"/>
+  <rect x="5" y="2" width="22" height="28" rx="3" fill="#FFE01B" stroke="#1A1207" stroke-width="2"/>
+  <rect x="8" y="5" width="16" height="8" rx="1.5" fill="#1A1207"/>
+  <rect x="8" y="16" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="18" y="16" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="8" y="22.5" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="18" y="22.5" width="6" height="4.5" rx="1" fill="#1A1207"/>
+</svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, Fragment } from "react";
+import Image from "next/image";
 import type { YarnWeightKey } from "@/lib/yarnWeights";
 import styles from "./page.module.css";
 import ResultsPanel from "@/components/ResultsPanel";
@@ -176,7 +177,7 @@ export default function Home() {
       <header className={styles.header}>
         <div className={styles.headerInner}>
           <div className={styles.logo}>
-            <YarnIcon />
+            <Image src="/icon.svg" alt="" width={30} height={30} aria-hidden />
             <span>Gauge Calculator</span>
           </div>
           <button
@@ -504,25 +505,6 @@ export default function Home() {
 
 /* ── Inline SVG components ── */
 
-function YarnIcon() {
-  return (
-    <svg
-      width="30"
-      height="30"
-      viewBox="0 0 30 30"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
-      <rect x="5" y="2" width="20" height="26" rx="3" fill="#FFE01B" stroke="#1A1207" strokeWidth="2" />
-      <rect x="8" y="5" width="14" height="7" rx="1.5" fill="#1A1207" />
-      <rect x="8" y="15" width="5.5" height="4" rx="1" fill="#1A1207" />
-      <rect x="16.5" y="15" width="5.5" height="4" rx="1" fill="#1A1207" />
-      <rect x="8" y="21" width="5.5" height="4" rx="1" fill="#1A1207" />
-      <rect x="16.5" y="21" width="5.5" height="4" rx="1" fill="#1A1207" />
-    </svg>
-  );
-}
 
 function HeroIllustration() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -514,11 +514,12 @@ function YarnIcon() {
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >
-      <circle cx="15" cy="15" r="13" fill="#FFE01B" stroke="#1A1207" strokeWidth="2" />
-      <ellipse cx="15" cy="15" rx="8" ry="13" stroke="#1A1207" strokeWidth="1.5" fill="none" />
-      <ellipse cx="15" cy="15" rx="13" ry="6" stroke="#1A1207" strokeWidth="1.5" fill="none" />
-      <path d="M6 10 Q15 7 24 11" stroke="#1A1207" strokeWidth="1.2" fill="none" strokeLinecap="round" />
-      <path d="M5 18 Q15 15 25 19" stroke="#1A1207" strokeWidth="1.2" fill="none" strokeLinecap="round" />
+      <rect x="5" y="2" width="20" height="26" rx="3" fill="#FFE01B" stroke="#1A1207" strokeWidth="2" />
+      <rect x="8" y="5" width="14" height="7" rx="1.5" fill="#1A1207" />
+      <rect x="8" y="15" width="5.5" height="4" rx="1" fill="#1A1207" />
+      <rect x="16.5" y="15" width="5.5" height="4" rx="1" fill="#1A1207" />
+      <rect x="8" y="21" width="5.5" height="4" rx="1" fill="#1A1207" />
+      <rect x="16.5" y="21" width="5.5" height="4" rx="1" fill="#1A1207" />
     </svg>
   );
 }

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="#FFE01B"/>
+  <rect x="5" y="2" width="22" height="28" rx="3" fill="#FFE01B" stroke="#1A1207" stroke-width="2"/>
+  <rect x="8" y="5" width="16" height="8" rx="1.5" fill="#1A1207"/>
+  <rect x="8" y="16" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="18" y="16" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="8" y="22.5" width="6" height="4.5" rx="1" fill="#1A1207"/>
+  <rect x="18" y="22.5" width="6" height="4.5" rx="1" fill="#1A1207"/>
+</svg>


### PR DESCRIPTION
Swaps out the globe-style yarn icon in the header logo for a clean, minimal calculator SVG. The new icon uses the existing brand colors (yellow body, dark display and buttons) and fits the same 30×30 footprint.